### PR TITLE
Allow the user to configure the path where webhooks are forwarded

### DIFF
--- a/webhook/forward.go
+++ b/webhook/forward.go
@@ -101,7 +101,7 @@ type wsEventReceived struct {
 	Body   []byte
 }
 
-func runFwd(out io.Writer, port int, path string, token, wsURL string, activateHook func() error) error {
+func runFwd(out io.Writer, port int, path, token, wsURL string, activateHook func() error) error {
 	for i := 0; i < 3; i++ {
 		err := handleWebsocket(out, port, path, token, wsURL, activateHook)
 		if err != nil {
@@ -117,7 +117,7 @@ func runFwd(out io.Writer, port int, path string, token, wsURL string, activateH
 }
 
 // handleWebsocket mediates between websocket server and local web server
-func handleWebsocket(out io.Writer, port int, path string, token, url string, activateHook func() error) error {
+func handleWebsocket(out io.Writer, port int, path, token, url string, activateHook func() error) error {
 	c, err := dial(token, url)
 	if err != nil {
 		return fmt.Errorf("error dialing to ws server: %w", err)

--- a/webhook/forward.go
+++ b/webhook/forward.go
@@ -181,7 +181,7 @@ func forwardEvent(port int, path string, ev wsEventReceived) (*httpEventForward,
 		fmt.Printf("%s\n", ev.Body)
 		return &httpEventForward{Status: 200, Header: make(http.Header), Body: []byte("OK")}, nil
 	}
-	webhookRcvServerURL := fmt.Sprintf("http://localhost:%d%s", port, path)
+	webhookRcvServerURL := fmt.Sprintf("http://localhost:%d/%s", port, strings.TrimPrefix(path, "/"))
 
 	req, err := http.NewRequest(http.MethodPost, webhookRcvServerURL, bytes.NewReader(ev.Body))
 	if err != nil {


### PR DESCRIPTION
This allows users to configure `gh webhook forward` to send their webhooks to a path other than `/` on their chosen `localhost` port. For example, you might locate your webhook handler at `/github`.

I use the slightly awkwardly-named `--delivery-path`/`-D` argument because the natural letter, `P`, is already taken by `--part`.