### PR TITLE
Document how to forward all events

### DIFF
--- a/webhook/forward.go
+++ b/webhook/forward.go
@@ -85,7 +85,7 @@ func NewCmdForward(runF func(*hookOptions) error) *cobra.Command {
 			return err
 		},
 	}
-	cmd.Flags().StringSliceVarP(&opts.EventTypes, "events", "E", []string{}, "(required) Names of the event types to forward. Event types can be separated by commas (e.g. `issues,pull_request`) or passed as multiple arguments (e.g. `--events issues --events pull_request`.")
+	cmd.Flags().StringSliceVarP(&opts.EventTypes, "events", "E", []string{}, "(required) Names of the event types to forward. Event types can be separated by commas (e.g. `issues,pull_request`) or passed as multiple arguments (e.g. `--events issues --events pull_request`). Use `*` to forward all events.")
 	cmd.Flags().StringVarP(&opts.Repo, "repo", "R", "", "Name of the repo where the webhook is installed")
 	cmd.Flags().StringVarP(&opts.GitHubHost, "github-host", "H", "", "(optional) Host for the GitHub API, default: api.github.com")
 	cmd.Flags().StringVarP(&opts.URL, "url", "U", "", "(optional) Local address where the server which will receive webhooks is running")


### PR DESCRIPTION
It took me a couple minutes to find how to use the equivalent of the "Send me everything." option from the website, so I figured it might help others to include that in the help page.
